### PR TITLE
Assert solc_version within sol compiler

### DIFF
--- a/cheb3/utils.py
+++ b/cheb3/utils.py
@@ -85,6 +85,7 @@ def compile_sol(
         bytecode.
     :rtype: Dict[str, Tuple[Dict, str]]
     """
+    assert solc_version is not None, 'solc_version must be set'
 
     try:
         set_solc_version(solc_version)


### PR DESCRIPTION
Explicitly throwing an error that `solc_version` must be set would make much more sense than reading such errors

```pytb
Traceback (most recent call last):
  File "E:\repos\es3n1n\...\test.py", line 7, in <module>
    abi, bytecode = compile_sol('''// SPDX-License-Identifier: UNLICENSED
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\repos\es3n1n\...\venv\Lib\site-packages\cheb3\utils.py", line 90, in compile_sol
    set_solc_version(solc_version)
  File "E:\repos\es3n1n\...\venv\Lib\site-packages\solcx\install.py", line 223, in set_solc_version
    version = _convert_and_validate_version(version)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\repos\es3n1n\...\venv\Lib\site-packages\solcx\install.py", line 69, in _convert_and_validate_version
    version = Version(version.lstrip("v"))
                      ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lstrip'
```